### PR TITLE
Updated browserify to version 11.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "optionalDependencies": {
     "brfs": "1.4.1",
-    "browserify": "11.1.0",
+    "browserify": "11.2.0",
     "uglifyjs": "2.4.10",
     "zlib-browserify": "0.0.3"
   },


### PR DESCRIPTION
:rocket:

browserify just published version 11.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [b7cf5be](https://github.com/substack/node-browserify/commit/b7cf5bef990a6823d14e2d437e15112aa6b3adfa): 11.2.0
- [bb2a99d](https://github.com/substack/node-browserify/commit/bb2a99dd6cb24899ca82ca898cbe4ab9e7002430): Merge pull request #1361 from substack/fix-bare
- [e781d9d](https://github.com/substack/node-browserify/commit/e781d9da9577c233b35201763bc75111b862b1b8): Merge pull request #1377 from demohi/patch-2
- [97a122e](https://github.com/substack/node-browserify/commit/97a122e9c885158733e0fa2f4eecf5d238202381): Update travis Node.js version & remove io.js
- [cf32d77](https://github.com/substack/node-browserify/commit/cf32d77b28a3a1c429063740842c5d35a6651de0): Exclude "process" and "buffer" when "bundleExternal === false"
- [7487bff](https://github.com/substack/node-browserify/commit/7487bff8f4ae8fc150778b10a91dc4c78233f801): Fix "--bare" and "--igv"

See the [full diff](https://github.com/substack/node-browserify/compare/05d786175e13b873c49afc40170a0428eb56354c...b7cf5bef990a6823d14e2d437e15112aa6b3adfa).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
